### PR TITLE
Rewrite to work with the current version of kartik/fileinput

### DIFF
--- a/views/default/view.php
+++ b/views/default/view.php
@@ -153,7 +153,6 @@ $(document).ready(function() {
     }).on("filebatchselected", function(event, files) {
         inputField.fileinput("upload");
     });
-
     
     inputField.on('fileunlock', function(event, filestack, extraData) {
         location.reload();

--- a/views/default/view.php
+++ b/views/default/view.php
@@ -138,6 +138,7 @@ $(document).ready(function() {
         showPreview: false,
         uploadUrl: 'fileupload',
         uploadAsync: true,
+        showUpload: false,
         uploadExtraData: {
            'gallery_id': "$model->gallery_id",
            'gallery_name': "$model->name",
@@ -149,19 +150,13 @@ $(document).ready(function() {
            'class': 'alert-warning-message'
         },
         elErrorContainer: '#errorBlock'
+    }).on("filebatchselected", function(event, files) {
+        inputField.fileinput("upload");
     });
+
     
     inputField.on('fileunlock', function(event, filestack, extraData) {
-        var fstack = [];
-        $.each(filestack, function(fileId, file) {
-            if (file) {
-                fstack.push(file);
-            }
-        });
-        
-        if (fstack.length === 0) {
-            location.reload();
-        }
+        location.reload();
     });
 });
 JS

--- a/views/default/view.php
+++ b/views/default/view.php
@@ -151,8 +151,17 @@ $(document).ready(function() {
         elErrorContainer: '#errorBlock'
     });
     
-    inputField.on('fileunlock', function(event, data, previewId, index) {
-        location.reload();
+    inputField.on('fileunlock', function(event, filestack, extraData) {
+        var fstack = [];
+        $.each(filestack, function(fileId, file) {
+            if (file) {
+                fstack.push(file);
+            }
+        });
+        
+        if (fstack.length === 0) {
+            location.reload();
+        }
     });
 });
 JS


### PR DESCRIPTION
The previous version of the event fileunlock (kartik/fileinput) does not work anymore. The fix fixes that in the default view.